### PR TITLE
Fixed UICollectionViewFlowLayout warning

### DIFF
--- a/Classes/ALGReversedFlowLayout.m
+++ b/Classes/ALGReversedFlowLayout.m
@@ -64,7 +64,7 @@
 
 - (UICollectionViewLayoutAttributes *) layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  UICollectionViewLayoutAttributes * attribute = [super layoutAttributesForItemAtIndexPath:indexPath];
+  UICollectionViewLayoutAttributes * attribute = [[super layoutAttributesForItemAtIndexPath:indexPath] copy];
   [self modifyLayoutAttribute:attribute];
   return attribute;
 }
@@ -73,10 +73,13 @@
 {
   CGRect const normalRect = [self normalRectForReversedRect:reversedRect];
   NSArray * attributes = [super layoutAttributesForElementsInRect:normalRect];
+  NSMutableArray *result = [NSMutableArray arrayWithCapacity:attributes.count];
   for(UICollectionViewLayoutAttributes *attribute in attributes){
-    [self modifyLayoutAttribute:attribute];
+    UICollectionViewLayoutAttributes *attr = [attribute copy];
+    [self modifyLayoutAttribute:attr];
+    [result addObject:attr];
   }
-  return attributes;
+  return result;
 }
 
 - (void) setScrollDirection:(UICollectionViewScrollDirection)scrollDirection


### PR DESCRIPTION
2015-11-30 23:19:09.869 [97715:12358348] Logging only once for UICollectionViewFlowLayout cache mismatched frame
2015-11-30 23:19:09.870 [97715:12358348] UICollectionViewFlowLayout has cached frame mismatch for index path <NSIndexPath: 0xc000000001600016> {length = 2, path = 0 - 11} - cached value: {{0, 0}, {320, 1399}}; expected value: {{0, 15499}, {320, 1399}}
2015-11-30 23:19:09.870 [97715:12358348] This is likely occurring because the flow layout subclass ALGReversedFlowLayout is modifying attributes returned by UICollectionViewFlowLayout without copying them
